### PR TITLE
Show program metadata from web service - static site version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +360,32 @@ name = "camino"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "cc"
@@ -838,9 +870,11 @@ name = "entropy-network-status-page"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "console_error_panic_hook",
  "console_log",
  "entropy-shared",
+ "futures",
  "hex",
  "http",
  "leptos",
@@ -849,7 +883,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "pretty-bytes-rust",
+ "reqwest",
  "serde",
+ "serde_json",
  "simple_logger",
  "subxt",
  "thiserror",
@@ -880,10 +916,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fiat-crypto"
@@ -908,6 +960,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1340,6 +1407,19 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -1844,6 +1924,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,6 +2022,24 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2048,10 +2152,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "pad-adapter"
@@ -2166,6 +2308,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "platforms"
@@ -2414,7 +2562,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2470,19 +2618,23 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2573,6 +2725,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2816,7 +2981,7 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2844,6 +3009,9 @@ name = "semver"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "send_wrapper"
@@ -3421,7 +3589,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3441,6 +3609,18 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "thiserror"
@@ -3565,6 +3745,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -3828,6 +4018,12 @@ checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,11 @@ web-sys = { version = "0.3.66", features = ["Navigator", "Clipboard"]}
 wasm-bindgen-futures = "0.4.39"
 pretty-bytes-rust = "0.1.0"
 anyhow = "1.0.75"
-parity-scale-codec="3.0.0"
+parity-scale-codec = "3.0.0"
+futures = "0.3.30"
+reqwest = "0.11.23"
+cargo_metadata = "0.18.1"
+serde_json = "1.0.113"
 
 # Defines a size-optimized profile for the WASM bundle in release mode
 [profile.wasm-release]

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,6 +138,7 @@ fn HomePage() -> impl IntoView {
                                 "Times Used",
                                 "Size",
                                 "Configurable?",
+                                "Metadata",
                             ]
                         >
 

--- a/src/program.rs
+++ b/src/program.rs
@@ -3,6 +3,8 @@ use crate::chain_api::EntropyConfig;
 use crate::get_api_rpc;
 use crate::{display_bytes, DisplayValue};
 use anyhow::anyhow;
+use cargo_metadata::Package;
+use futures::stream::{self, StreamExt};
 use leptos::*;
 use parity_scale_codec::Decode;
 use serde::{Deserialize, Serialize};
@@ -12,6 +14,8 @@ use subxt::{
     Config, OnlineClient,
 };
 
+const PROGRAM_METADATA_SERVICE: &str = "http://127.0.0.1:3000";
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Program {
     pub hash: String,
@@ -19,10 +23,16 @@ pub struct Program {
     pub ref_counter: u128,
     pub size: usize,
     pub configurable: bool,
+    pub name: Option<String>,
 }
 
 impl Program {
-    fn new(hash: H256, program_info: ProgramInfo<AccountId32>) -> Program {
+    fn new(
+        hash: H256,
+        program_info: ProgramInfo<AccountId32>,
+        metadata: Option<Package>,
+    ) -> Program {
+        let name = metadata.map(|m| m.name);
         Program {
             hash: hash.to_string(),
             deployer: program_info.deployer.to_string(),
@@ -31,6 +41,7 @@ impl Program {
             // TODO: If configuration interface is json we could display it. Waiting till
             // we have an example of a program with a configuration interface
             configurable: !program_info.configuration_interface.is_empty(),
+            name,
         }
     }
 }
@@ -59,6 +70,11 @@ pub fn Program(program: Program) -> impl IntoView {
                     {program.configurable}
                 </p>
             </td>
+            <td class="p-4">
+                <p class="block font-sans text-sm antialiased font-normal leading-normal text-blue-gray-900">
+                    {program.name.unwrap_or_default()}
+                </p>
+            </td>
         </tr>
     }
 }
@@ -66,14 +82,21 @@ pub fn Program(program: Program) -> impl IntoView {
 pub async fn get_stored_programs() -> Result<Vec<Program>, ServerFnError> {
     let (api, rpc) = get_api_rpc().await?;
 
-    let programs = get_programs(&api, &rpc)
+    let programs_iter = get_programs(&api, &rpc)
         .await
         .map_err(|e| ServerFnError::ServerError(e.to_string()))?
         .into_iter()
-        .map(|(hash, program_info)| Program::new(hash, program_info))
-        .collect();
+        // .map(|(hash, program_info)| Program::new(hash, program_info))
+        // .collect();
+        .map(|(hash, program_info)| async move {
+            let metadata = get_program_metadata(hash).await;
+            Program::new(hash, program_info, metadata)
+        });
 
-    Ok(programs)
+    // Only allow 3 concurrent http requests at a time (TODO could speed things up by increasing
+    // this)
+    let programs_stream = stream::iter(programs_iter).buffer_unordered(3);
+    Ok(programs_stream.collect::<Vec<Program>>().await)
 }
 
 /// Get details of all stored programs
@@ -97,4 +120,22 @@ pub async fn get_programs(
         programs.push((H256(hash), program_info));
     }
     Ok(programs)
+}
+
+/// Attempt to get program's metadata from the http service. If there is any problem,
+/// return None
+async fn get_program_metadata(hash: H256) -> Option<Package> {
+    let response_string = reqwest::get(format!(
+        "{}/program/{}",
+        PROGRAM_METADATA_SERVICE,
+        hex::encode(hash)
+    ))
+    .await
+    .ok()?
+    .text()
+    .await
+    .ok()?;
+
+    let package: Package = serde_json::from_str(&response_string).ok()?;
+    Some(package)
 }


### PR DESCRIPTION
This is the same as https://github.com/entropyxyz/entropy-network-status-page/pull/2 but based on https://github.com/entropyxyz/entropy-network-status-page/pull/6 to avoid messy conflicts